### PR TITLE
Update nanoleaf-testing package.json

### DIFF
--- a/nanoleaf-testing/package.json
+++ b/nanoleaf-testing/package.json
@@ -1,16 +1,17 @@
 {
     "name": "nanoleaf-testing",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch-pubsub": "0.1.0",
-            "nodecg-io-twitch": "0.1.0"
+            "nodecg-io-twitch-pubsub": "^0.1.0"
         }
     },
     "scripts": {
-        "build": "tsc",
-        "watch": "tsc -w"
+        "build": "tsc -b",
+        "watch": "tsc -b -w",
+        "clean": "tsc -b --clean"
     },
     "license": "MIT",
     "devDependencies": {
@@ -20,8 +21,8 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.1",
-        "nodecg-io-twitch-pubsub": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-twitch-pubsub": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"
     }


### PR DESCRIPTION
Updates the nanoleaf-testing package.json to reflect the latest changes
from the nodecg-io samples.

- Set the package to private, so it can't be accidentially published
- Use semver range operator in nodecg-io package versions to
  automatically get fix releases when npm installing
- Use typescript build mode for incremental compiling and add clean
  script

Also removes bundle dependency on nodecg-io-twitch since it isn't used
here anymore and is also not in the normal dependencies.