### PR TITLE
Get HypeTrains from twitch-api package

### DIFF
--- a/nanoleaf-testing/package-lock.json
+++ b/nanoleaf-testing/package-lock.json
@@ -19,11 +19,6 @@
 				"@types/node": "*"
 			}
 		},
-		"dotenv": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-		},
 		"nodecg": {
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/nodecg/-/nodecg-1.7.4.tgz",

--- a/nanoleaf-testing/package.json
+++ b/nanoleaf-testing/package.json
@@ -16,12 +16,10 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/ws": "^7.2.6",
         "@types/node": "^14.6.4",
         "@types/node-fetch": "^2.5.7"
     },
     "dependencies": {
-        "dotenv": "^8.2.0",
         "node-fetch": "^2.6.1",
         "nodecg": "^1.6.1",
         "nodecg-io-core": "^0.1.0",


### PR DESCRIPTION
The bug in the twitch library regarding HypeTrains has now been fixed and is with https://github.com/codeoverflow-org/nodecg-io/pull/176 also fixed in the newest nodecg-io version.
Can't test this, but I hope it works.