### PR TITLE
Update `lerna.json` example in install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ skate702's custom nodecg-io bundles live from the stream at [skate702.tv](https:
 
     ```json
     {
-        "packages": ["nodecg-io-*", "nodecg-io-core/dashboard", "samples/*", "skates-bundles/*"],
-        "version": "0.1.0"
+        "packages": ["nodecg-io-*", "nodecg-io-core/dashboard", "samples/*", "utils/*", "skates-bundles/*"],
+        "version": "0.2.0"
     }
     ```
 


### PR DESCRIPTION
Since the creation of the installation guide the `lerna.json` file has been changed twice:
- updated version to `0.2.0`
- added `utils/*` directory, which currently only contains `nodecg-io-twitch-auth`

This PR updates the `lerna.json` inside the README to reflect these two changes.