### PR TITLE
Use `nodecg-types` for nodecg types instead of `nodecg`

### DIFF
--- a/nanoleaf-events/extension/NanoleafEventManager.ts
+++ b/nanoleaf-events/extension/NanoleafEventManager.ts
@@ -3,7 +3,7 @@ import { NanoleafServiceClient } from "nodecg-io-nanoleaf";
 import { TwitchApiServiceClient } from "nodecg-io-twitch-api";
 import { TwitchPubSubServiceClient } from "nodecg-io-twitch-pubsub";
 import { NanoleafUtils } from "nodecg-io-nanoleaf/extension/nanoleafUtils";
-import { NodeCG } from "nodecg/types/server";
+import { NodeCG } from "nodecg-types/types/server";
 import { PubSubRedemptionMessage } from 'twitch-pubsub-client';
 import { SubEventUtils } from "./SubEventUtils";
 import { Manager } from "skates-utils";

--- a/nanoleaf-events/extension/index.ts
+++ b/nanoleaf-events/extension/index.ts
@@ -1,4 +1,4 @@
-import { NodeCG } from "nodecg/types/server";
+import { NodeCG } from "nodecg-types/types/server";
 import { TwitchPubSubServiceClient } from "nodecg-io-twitch-pubsub";
 import { TwitchApiServiceClient } from "nodecg-io-twitch-api";
 import { NanoleafServiceClient } from "nodecg-io-nanoleaf";

--- a/nanoleaf-events/package-lock.json
+++ b/nanoleaf-events/package-lock.json
@@ -5,8 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "nanoleaf-events",
 			"version": "0.2.0",
 			"license": "MIT",
+			"dependencies": {
+				"nodecg-types": "^1.8.1"
+			},
 			"devDependencies": {
 				"@types/node": "^14.14.33",
 				"@types/node-fetch": "^2.5.8",
@@ -91,6 +95,183 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"dependencies": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/body-parser": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+			"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/component-emitter": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/createjs-lib": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+			"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+		},
+		"node_modules/nodecg-types/node_modules/@types/engine.io": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+			"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express": {
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.18",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express-serve-static-core": {
+			"version": "4.17.24",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+			"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/mime": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/node": {
+			"version": "16.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+			"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/preloadjs": {
+			"version": "0.6.32",
+			"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+			"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+			"dependencies": {
+				"@types/createjs-lib": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/qs": {
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/serve-static": {
+			"version": "1.13.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+			"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+			"dependencies": {
+				"@types/engine.io": "*",
+				"@types/node": "*",
+				"@types/socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-client": {
+			"version": "1.4.36",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+			"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+			"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+			"deprecated": "This is a stub types definition. socket.io-parser provides its own type definitions, so you do not need this installed.",
+			"dependencies": {
+				"socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/soundjs": {
+			"version": "0.6.28",
+			"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+			"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+			"dependencies": {
+				"@types/createjs-lib": "*",
+				"@types/preloadjs": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+		},
+		"node_modules/nodecg-types/node_modules/debug": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/nodecg-types/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/nodecg-types/node_modules/socket.io-parser": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+			"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+			"dependencies": {
+				"@types/component-emitter": "^1.2.10",
+				"component-emitter": "~1.3.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
@@ -167,6 +348,173 @@
 					"dev": true,
 					"requires": {
 						"mime-db": "1.48.0"
+					}
+				}
+			}
+		},
+		"nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"requires": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			},
+			"dependencies": {
+				"@types/body-parser": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+					"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+					"requires": {
+						"@types/connect": "*",
+						"@types/node": "*"
+					}
+				},
+				"@types/component-emitter": {
+					"version": "1.2.10",
+					"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+					"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+				},
+				"@types/connect": {
+					"version": "3.4.35",
+					"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+					"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/createjs-lib": {
+					"version": "0.0.29",
+					"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+					"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+				},
+				"@types/engine.io": {
+					"version": "3.1.7",
+					"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+					"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/express": {
+					"version": "4.17.13",
+					"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+					"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+					"requires": {
+						"@types/body-parser": "*",
+						"@types/express-serve-static-core": "^4.17.18",
+						"@types/qs": "*",
+						"@types/serve-static": "*"
+					}
+				},
+				"@types/express-serve-static-core": {
+					"version": "4.17.24",
+					"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+					"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+					"requires": {
+						"@types/node": "*",
+						"@types/qs": "*",
+						"@types/range-parser": "*"
+					}
+				},
+				"@types/mime": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+					"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+				},
+				"@types/node": {
+					"version": "16.10.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+					"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+				},
+				"@types/preloadjs": {
+					"version": "0.6.32",
+					"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+					"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+					"requires": {
+						"@types/createjs-lib": "*"
+					}
+				},
+				"@types/qs": {
+					"version": "6.9.7",
+					"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+					"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+				},
+				"@types/range-parser": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+					"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+				},
+				"@types/serve-static": {
+					"version": "1.13.10",
+					"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+					"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+					"requires": {
+						"@types/mime": "^1",
+						"@types/node": "*"
+					}
+				},
+				"@types/socket.io": {
+					"version": "2.1.13",
+					"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+					"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+					"requires": {
+						"@types/engine.io": "*",
+						"@types/node": "*",
+						"@types/socket.io-parser": "*"
+					}
+				},
+				"@types/socket.io-client": {
+					"version": "1.4.36",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+					"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+				},
+				"@types/socket.io-parser": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+					"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+					"requires": {
+						"socket.io-parser": "*"
+					}
+				},
+				"@types/soundjs": {
+					"version": "0.6.28",
+					"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+					"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+					"requires": {
+						"@types/createjs-lib": "*",
+						"@types/preloadjs": "*"
+					}
+				},
+				"component-emitter": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"socket.io-parser": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+					"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+					"requires": {
+						"@types/component-emitter": "^1.2.10",
+						"component-emitter": "~1.3.0",
+						"debug": "~4.3.1"
 					}
 				}
 			}

--- a/nanoleaf-events/package.json
+++ b/nanoleaf-events/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.1",
-        "nodecg": "^1.8.1",
+        "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.2.0",
         "nodecg-io-twitch-api": "^0.2.0",
         "nodecg-io-twitch-pubsub": "^0.2.0",

--- a/skates-utils/Manager.ts
+++ b/skates-utils/Manager.ts
@@ -1,5 +1,5 @@
 import { ServiceProvider } from "nodecg-io-core";
-import { NodeCG } from "nodecg/types/server";
+import { NodeCG } from "nodecg-types/types/server";
 
 export class Manager {
 

--- a/skates-utils/package-lock.json
+++ b/skates-utils/package-lock.json
@@ -5,8 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "skates-utils",
 			"version": "0.2.0",
 			"license": "MIT",
+			"dependencies": {
+				"nodecg-types": "^1.8.1"
+			},
 			"devDependencies": {
 				"@types/node": "^14.14.33",
 				"typescript": "^4.2.3"
@@ -17,6 +21,183 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
 			"integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
 			"dev": true
+		},
+		"node_modules/nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"dependencies": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/body-parser": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+			"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/component-emitter": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/createjs-lib": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+			"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+		},
+		"node_modules/nodecg-types/node_modules/@types/engine.io": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+			"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express": {
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.18",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express-serve-static-core": {
+			"version": "4.17.24",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+			"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/mime": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/node": {
+			"version": "16.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+			"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/preloadjs": {
+			"version": "0.6.32",
+			"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+			"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+			"dependencies": {
+				"@types/createjs-lib": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/qs": {
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/serve-static": {
+			"version": "1.13.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+			"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+			"dependencies": {
+				"@types/engine.io": "*",
+				"@types/node": "*",
+				"@types/socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-client": {
+			"version": "1.4.36",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+			"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+			"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+			"deprecated": "This is a stub types definition. socket.io-parser provides its own type definitions, so you do not need this installed.",
+			"dependencies": {
+				"socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/soundjs": {
+			"version": "0.6.28",
+			"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+			"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+			"dependencies": {
+				"@types/createjs-lib": "*",
+				"@types/preloadjs": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+		},
+		"node_modules/nodecg-types/node_modules/debug": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/nodecg-types/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/nodecg-types/node_modules/socket.io-parser": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+			"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+			"dependencies": {
+				"@types/component-emitter": "^1.2.10",
+				"component-emitter": "~1.3.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "4.3.2",
@@ -38,6 +219,173 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
 			"integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
 			"dev": true
+		},
+		"nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"requires": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			},
+			"dependencies": {
+				"@types/body-parser": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+					"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+					"requires": {
+						"@types/connect": "*",
+						"@types/node": "*"
+					}
+				},
+				"@types/component-emitter": {
+					"version": "1.2.10",
+					"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+					"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+				},
+				"@types/connect": {
+					"version": "3.4.35",
+					"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+					"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/createjs-lib": {
+					"version": "0.0.29",
+					"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+					"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+				},
+				"@types/engine.io": {
+					"version": "3.1.7",
+					"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+					"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/express": {
+					"version": "4.17.13",
+					"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+					"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+					"requires": {
+						"@types/body-parser": "*",
+						"@types/express-serve-static-core": "^4.17.18",
+						"@types/qs": "*",
+						"@types/serve-static": "*"
+					}
+				},
+				"@types/express-serve-static-core": {
+					"version": "4.17.24",
+					"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+					"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+					"requires": {
+						"@types/node": "*",
+						"@types/qs": "*",
+						"@types/range-parser": "*"
+					}
+				},
+				"@types/mime": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+					"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+				},
+				"@types/node": {
+					"version": "16.10.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+					"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+				},
+				"@types/preloadjs": {
+					"version": "0.6.32",
+					"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+					"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+					"requires": {
+						"@types/createjs-lib": "*"
+					}
+				},
+				"@types/qs": {
+					"version": "6.9.7",
+					"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+					"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+				},
+				"@types/range-parser": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+					"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+				},
+				"@types/serve-static": {
+					"version": "1.13.10",
+					"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+					"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+					"requires": {
+						"@types/mime": "^1",
+						"@types/node": "*"
+					}
+				},
+				"@types/socket.io": {
+					"version": "2.1.13",
+					"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+					"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+					"requires": {
+						"@types/engine.io": "*",
+						"@types/node": "*",
+						"@types/socket.io-parser": "*"
+					}
+				},
+				"@types/socket.io-client": {
+					"version": "1.4.36",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+					"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+				},
+				"@types/socket.io-parser": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+					"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+					"requires": {
+						"socket.io-parser": "*"
+					}
+				},
+				"@types/soundjs": {
+					"version": "0.6.28",
+					"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+					"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+					"requires": {
+						"@types/createjs-lib": "*",
+						"@types/preloadjs": "*"
+					}
+				},
+				"component-emitter": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"socket.io-parser": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+					"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+					"requires": {
+						"@types/component-emitter": "^1.2.10",
+						"component-emitter": "~1.3.0",
+						"debug": "~4.3.1"
+					}
+				}
+			}
 		},
 		"typescript": {
 			"version": "4.3.2",

--- a/skates-utils/package.json
+++ b/skates-utils/package.json
@@ -17,7 +17,7 @@
         "typescript": "^4.2.3"
     },
     "dependencies": {
-        "nodecg": "^1.8.1",
+        "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.2.0"
     }
 }

--- a/was/extension/DBController.ts
+++ b/was/extension/DBController.ts
@@ -1,4 +1,4 @@
-import { NodeCG, ReplicantServer } from "nodecg/types/server";
+import { NodeCG, ReplicantServer } from "nodecg-types/types/server";
 import { Message } from "./types";
 import { SQLCLient } from "nodecg-io-sql";
 import { ServiceProvider } from "nodecg-io-core";

--- a/was/extension/MessageController.ts
+++ b/was/extension/MessageController.ts
@@ -1,4 +1,4 @@
-import { NodeCG, ReplicantServer } from "nodecg/types/server";
+import { NodeCG, ReplicantServer } from "nodecg-types/types/server";
 import { Message, PresetCollection } from "./types";
 
 export class MessageController {

--- a/was/extension/WasCommandManager.ts
+++ b/was/extension/WasCommandManager.ts
@@ -1,6 +1,6 @@
 import { ServiceProvider } from "nodecg-io-core";
 import { TwitchChatServiceClient } from "nodecg-io-twitch-chat";
-import { NodeCG } from "nodecg/types/server";
+import { NodeCG } from "nodecg-types/types/server";
 import { Manager } from "skates-utils";
 import { TwitchApiServiceClient } from "nodecg-io-twitch-api";
 import { MessageController } from "./MessageController";

--- a/was/extension/index.ts
+++ b/was/extension/index.ts
@@ -1,4 +1,4 @@
-import { NodeCG } from "nodecg/types/server";
+import { NodeCG } from "nodecg-types/types/server";
 import { TwitchChatServiceClient } from "nodecg-io-twitch-chat";
 import { requireService } from "nodecg-io-core";
 import { WasCommandManager } from "./WasCommandManager";

--- a/was/package-lock.json
+++ b/was/package-lock.json
@@ -5,8 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "was",
 			"version": "0.2.0",
 			"license": "MIT",
+			"dependencies": {
+				"nodecg-types": "^1.8.1"
+			},
 			"devDependencies": {
 				"@types/node": "^14.14.33",
 				"@types/node-fetch": "^2.5.8",
@@ -91,6 +95,183 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"dependencies": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/body-parser": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+			"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/component-emitter": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/createjs-lib": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+			"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+		},
+		"node_modules/nodecg-types/node_modules/@types/engine.io": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+			"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express": {
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+			"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.18",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/express-serve-static-core": {
+			"version": "4.17.24",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+			"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/mime": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/node": {
+			"version": "16.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+			"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/preloadjs": {
+			"version": "0.6.32",
+			"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+			"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+			"dependencies": {
+				"@types/createjs-lib": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/qs": {
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/serve-static": {
+			"version": "1.13.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+			"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+			"dependencies": {
+				"@types/engine.io": "*",
+				"@types/node": "*",
+				"@types/socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-client": {
+			"version": "1.4.36",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+			"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+		},
+		"node_modules/nodecg-types/node_modules/@types/socket.io-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+			"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+			"deprecated": "This is a stub types definition. socket.io-parser provides its own type definitions, so you do not need this installed.",
+			"dependencies": {
+				"socket.io-parser": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/@types/soundjs": {
+			"version": "0.6.28",
+			"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+			"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+			"dependencies": {
+				"@types/createjs-lib": "*",
+				"@types/preloadjs": "*"
+			}
+		},
+		"node_modules/nodecg-types/node_modules/component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+		},
+		"node_modules/nodecg-types/node_modules/debug": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/nodecg-types/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/nodecg-types/node_modules/socket.io-parser": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+			"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+			"dependencies": {
+				"@types/component-emitter": "^1.2.10",
+				"component-emitter": "~1.3.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
@@ -167,6 +348,173 @@
 					"dev": true,
 					"requires": {
 						"mime-db": "1.46.0"
+					}
+				}
+			}
+		},
+		"nodecg-types": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.2.tgz",
+			"integrity": "sha512-CRTq1YJ51nk4g5xEafcHt/dqSpqmTQEI70NypyvZEMfBA9lEfd7+5XnJz1R9fZUCPqlJIkkB5DUpRqS03XhpOA==",
+			"requires": {
+				"@types/express": "^4.17.13",
+				"@types/node": "^16.7.1",
+				"@types/socket.io": "^2.1.2",
+				"@types/socket.io-client": "^1.4.32",
+				"@types/soundjs": "^0.6.28"
+			},
+			"dependencies": {
+				"@types/body-parser": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+					"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+					"requires": {
+						"@types/connect": "*",
+						"@types/node": "*"
+					}
+				},
+				"@types/component-emitter": {
+					"version": "1.2.10",
+					"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+					"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+				},
+				"@types/connect": {
+					"version": "3.4.35",
+					"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+					"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/createjs-lib": {
+					"version": "0.0.29",
+					"resolved": "https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz",
+					"integrity": "sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc="
+				},
+				"@types/engine.io": {
+					"version": "3.1.7",
+					"resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
+					"integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/express": {
+					"version": "4.17.13",
+					"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+					"integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+					"requires": {
+						"@types/body-parser": "*",
+						"@types/express-serve-static-core": "^4.17.18",
+						"@types/qs": "*",
+						"@types/serve-static": "*"
+					}
+				},
+				"@types/express-serve-static-core": {
+					"version": "4.17.24",
+					"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+					"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+					"requires": {
+						"@types/node": "*",
+						"@types/qs": "*",
+						"@types/range-parser": "*"
+					}
+				},
+				"@types/mime": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+					"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+				},
+				"@types/node": {
+					"version": "16.10.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+					"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
+				},
+				"@types/preloadjs": {
+					"version": "0.6.32",
+					"resolved": "https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz",
+					"integrity": "sha1-Es/3x/kuODingNQ4zknIzsmBgw0=",
+					"requires": {
+						"@types/createjs-lib": "*"
+					}
+				},
+				"@types/qs": {
+					"version": "6.9.7",
+					"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+					"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+				},
+				"@types/range-parser": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+					"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+				},
+				"@types/serve-static": {
+					"version": "1.13.10",
+					"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+					"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+					"requires": {
+						"@types/mime": "^1",
+						"@types/node": "*"
+					}
+				},
+				"@types/socket.io": {
+					"version": "2.1.13",
+					"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+					"integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+					"requires": {
+						"@types/engine.io": "*",
+						"@types/node": "*",
+						"@types/socket.io-parser": "*"
+					}
+				},
+				"@types/socket.io-client": {
+					"version": "1.4.36",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+					"integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
+				},
+				"@types/socket.io-parser": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
+					"integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
+					"requires": {
+						"socket.io-parser": "*"
+					}
+				},
+				"@types/soundjs": {
+					"version": "0.6.28",
+					"resolved": "https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz",
+					"integrity": "sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==",
+					"requires": {
+						"@types/createjs-lib": "*",
+						"@types/preloadjs": "*"
+					}
+				},
+				"component-emitter": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"socket.io-parser": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+					"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+					"requires": {
+						"@types/component-emitter": "^1.2.10",
+						"component-emitter": "~1.3.0",
+						"debug": "~4.3.1"
 					}
 				}
 			}

--- a/was/package.json
+++ b/was/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.1",
-        "nodecg": "^1.8.1",
+        "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.2.0",
         "nodecg-io-twitch-chat": "^0.2.0",
         "nodecg-io-twitch-api": "^0.2.0",


### PR DESCRIPTION
Refer to https://github.com/codeoverflow-org/nodecg-io/issues/239 / https://github.com/codeoverflow-org/nodecg-io/pull/246 for more details.

Bundles can freely choose between `nodecg` and `nodecg-types` for nodecg types (because they're 100% compatible). Because of the reasons detailed in the mentioned issue bundles should choose to use `nodecg-types` resulting less useless dependencies.

Before nodecg-io `0.2.0` will be released I'll also update the nodecg-io-cli to generate bundles depending on `nodecg-types` instead of `nodecg`.