### PR TITLE
Use common tsconfig from shared nodecg-io-tsconfig package

### DIFF
--- a/nanoleaf-events/package.json
+++ b/nanoleaf-events/package.json
@@ -21,6 +21,7 @@
         "node-fetch": "^2.6.1",
         "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.3.0",
+        "nodecg-io-tsconfig": "^1.0.0",
         "nodecg-io-twitch-api": "^0.3.0",
         "nodecg-io-twitch-pubsub": "^0.3.0",
         "nodecg-io-nanoleaf": "^0.3.0",

--- a/nanoleaf-events/tsconfig.json
+++ b/nanoleaf-events/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tsconfig.common.json"
+    "extends": "nodecg-io-tsconfig"
 }

--- a/skates-utils/package.json
+++ b/skates-utils/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "nodecg-types": "^1.8.1",
-        "nodecg-io-core": "^0.3.0"
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-tsconfig": "^1.0.0"
     }
 }

--- a/skates-utils/tsconfig.json
+++ b/skates-utils/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tsconfig.common.json"
+    "extends": "nodecg-io-tsconfig"
 }

--- a/stream-bar/package.json
+++ b/stream-bar/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.3.0",
+        "nodecg-io-tsconfig": "^1.0.0",
         "nodecg-io-streamelements": "^0.3.0",
         "nodecg-io-spotify": "^0.3.0",
         "skates-utils": "^0.3.0"

--- a/stream-bar/tsconfig.json
+++ b/stream-bar/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tsconfig.common.json"
+    "extends": "nodecg-io-tsconfig"
 }

--- a/was/package.json
+++ b/was/package.json
@@ -29,6 +29,7 @@
         "node-fetch": "^2.6.1",
         "nodecg-types": "^1.8.1",
         "nodecg-io-core": "^0.3.0",
+        "nodecg-io-tsconfig": "^1.0.0",
         "nodecg-io-twitch-chat": "^0.3.0",
         "nodecg-io-twitch-api": "^0.3.0",
         "nodecg-io-sql": "^0.3.0",

--- a/was/tsconfig.json
+++ b/was/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tsconfig.common.json"
+    "extends": "nodecg-io-tsconfig"
 }


### PR DESCRIPTION
No more ugly relative paths to the nodecg-io install, yaaaaay.
This is for https://github.com/codeoverflow-org/nodecg-io/pull/395.

No more relative paths also means that skates-bundles can now be installed in different locations, if the user wants to do that for some reason.